### PR TITLE
Allow builds to be cross compiled

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -32,8 +32,8 @@ ARG DAPPER_HOST_ARCH
 ARG DOWNLOADS_DIR=/usr/src/downloads
 ARG KERNEL_ARCH=arm64
 ARG KERNEL_URL=https://github.com/raspberrypi/linux.git
-ARG KERNEL_BRANCH=rpi-4.14.y
-ARG KERNEL_VERSION=4.14.114
+ARG KERNEL_BRANCH=rpi-4.19.y
+ARG KERNEL_VERSION=4.19.66
 ARG FIRMWARE_URL=https://github.com/raspberrypi/firmware.git
 ARG FIRMWARE_BRANCH=master
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,7 +5,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes apt-
 	apt-utils \
 	&& rm -rf /var/lib/apt/lists/*
 
-
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 		bc \
@@ -33,7 +32,6 @@ ARG DOWNLOADS_DIR=/usr/src/downloads
 ARG KERNEL_ARCH=arm64
 ARG KERNEL_URL=https://github.com/raspberrypi/linux.git
 ARG KERNEL_BRANCH=rpi-4.19.y
-ARG KERNEL_VERSION=4.19.66
 ARG FIRMWARE_URL=https://github.com/raspberrypi/firmware.git
 ARG FIRMWARE_BRANCH=master
 
@@ -48,7 +46,6 @@ ENV LANG en_US.UTF-8
 ENV KERNEL_URL=${KERNEL_URL} \
 	KERNEL_BRANCH=${KERNEL_BRANCH} \
 	KERNEL_ARCH=${KERNEL_ARCH} \
-	KERNEL_VERSION=${KERNEL_VERSION} \
 	FIRMWARE_URL=${FIRMWARE_URL} \
 	FIRMWARE_BRANCH=${FIRMWARE_BRANCH} \
 	DOWNLOADS=${DOWNLOADS_DIR}

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -31,7 +31,7 @@ ARG DAPPER_HOST_ARCH
 ARG DOWNLOADS_DIR=/usr/src/downloads
 ARG KERNEL_ARCH=arm64
 ARG KERNEL_URL=https://github.com/raspberrypi/linux.git
-ARG KERNEL_BRANCH=rpi-4.19.y
+ARG KERNEL_BRANCH=rpi-4.14.y
 ARG FIRMWARE_URL=https://github.com/raspberrypi/firmware.git
 ARG FIRMWARE_BRANCH=master
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,6 +5,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes apt-
 	apt-utils \
 	&& rm -rf /var/lib/apt/lists/*
 
+
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 		bc \
@@ -18,6 +19,10 @@ RUN apt-get update \
 		libncurses5-dev \
 		libssl-dev \
 		locales \
+	&& if [ "${DAPPER_HOST_ARCH}" != "arm64" ]; then \
+		DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		gcc-aarch64-linux-gnu; \
+		fi \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -f /bin/sh && ln -s /bin/bash /bin/sh
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,14 @@
 FROM debian:9
 # FROM arm64=arm64v8/debian:9
 
+ARG DAPPER_HOST_ARCH
+ARG DOWNLOADS_DIR=/usr/src/downloads
+ARG KERNEL_ARCH=arm64
+ARG KERNEL_URL=https://github.com/raspberrypi/linux.git
+ARG KERNEL_BRANCH=rpi-4.14.y
+ARG FIRMWARE_URL=https://github.com/raspberrypi/firmware.git
+ARG FIRMWARE_BRANCH=master
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes apt-get install -y --no-install-recommends \
 	apt-utils \
 	&& rm -rf /var/lib/apt/lists/*
@@ -26,14 +34,6 @@ RUN apt-get update \
 	&& rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-
-ARG DAPPER_HOST_ARCH
-ARG DOWNLOADS_DIR=/usr/src/downloads
-ARG KERNEL_ARCH=arm64
-ARG KERNEL_URL=https://github.com/raspberrypi/linux.git
-ARG KERNEL_BRANCH=rpi-4.14.y
-ARG FIRMWARE_URL=https://github.com/raspberrypi/firmware.git
-ARG FIRMWARE_BRANCH=master
 
 ENV DAPPER_ENV VERSION DEBUG
 ENV DAPPER_DOCKER_SOCKET true

--- a/scripts/build
+++ b/scripts/build
@@ -20,8 +20,13 @@ echo "`yellow [START]` build kernel and modules..."
 		# configure the kernel
 		$MAKE_CMD $DEF_CONFIG
 
-		# copy .config to the /source/build/kernel directory
+		# Save information about the built kernel
 		KERNEL_RELEASE=$($MAKE_CMD kernelrelease | grep "^[45]")
+		KERNEL_VERSION=$($MAKE_CMD kernelversion | grep "^[45]")
+		echo "$KERNEL_RELEASE" > /source/dist/kernelrelease
+		echo "v$KERNEL_VERSION-rancher" > /source/dist/version
+
+		# copy .config to the /source/build/kernel directory
 		cp .config /source/build/kernel/$KERNEL_RELEASE.config
 
 		# build kernel and modules

--- a/scripts/build
+++ b/scripts/build
@@ -21,12 +21,11 @@ echo "`yellow [START]` build kernel and modules..."
 		$MAKE_CMD $DEF_CONFIG
 
 		# copy .config to the /source/build/kernel directory
-		KERNEL_RELEASE=$($MAKE_CMD kernelrelease | grep "^4")
+		KERNEL_RELEASE=$($MAKE_CMD kernelrelease | grep "^[45]")
 		cp .config /source/build/kernel/$KERNEL_RELEASE.config
 
 		# build kernel and modules
-		$MAKE_CMD
-		$MAKE_CMD modules
+		$MAKE_CMD Image modules dtbs
 
 		# install kernel modules
 		INSTALL_DIR=${DOWNLOADS}/kernel/$KERNEL_RELEASE

--- a/scripts/build
+++ b/scripts/build
@@ -6,6 +6,10 @@ cd $(dirname $0)/..
 
 DEF_CONFIG=${DEFCONFIG:="bcmrpi3_defconfig"}
 MAKE_CMD="make -j $(nproc) ARCH=$KERNEL_ARCH"
+if [ $ARCH != $KERNEL_ARCH ]
+then
+	MAKE_CMD="${MAKE_CMD} CROSS_COMPILE=aarch64-linux-gnu-"
+fi
 
 echo "`yellow [START]` build kernel and modules..."
 	pushd ${DOWNLOADS}/kernel

--- a/scripts/package
+++ b/scripts/package
@@ -33,8 +33,10 @@ echo "`yellow [START]` package firmware files..."
 		FILE_LIST="
 		boot/LICENCE.*
 		boot/bootcode.bin
-		boot/fixup*.dat
-		boot/start*.elf
+		boot/fixup.dat
+		boot/fixup_cd.dat
+		boot/start.elf
+		boot/start_cd.elf
 		"
 		tar -cvzf rpi-bootloader.tar.gz $FILE_LIST
 		sha256sum rpi-bootloader.tar.gz > rpi-bootloader.tar.gz.sha256

--- a/scripts/package
+++ b/scripts/package
@@ -4,10 +4,13 @@ set -e
 source $(dirname $0)/color
 cd $(dirname $0)/..
 
+export KERNEL_VERSION=$(cat /source/dist/kernelrelease)
+
 : ${PACKAGE_KERNEL_DIR:=/source/dist/kernel}
 : ${PACKAGE_FIRMWARE_DIR:=/source/dist/firmware}
-: ${INSTALL_DIR:=$KERNEL_VERSION-rancheros-v8}
-: ${KERNEL_CONFIG:=$KERNEL_VERSION-rancheros-v8.config}
+: ${INSTALL_DIR:=$KERNEL_VERSION}
+: ${KERNEL_CONFIG:=$KERNEL_VERSION.config}
+echo $KERNEL_VERSION
 
 echo "`yellow [STARTING]` prepare package directories..."
 	mkdir -p $PACKAGE_KERNEL_DIR
@@ -16,8 +19,9 @@ echo "`green [FINISHED]` prepare package directories..."
 
 echo "`yellow [STARTING]` package kernel files..."
 	pushd ${DOWNLOADS}/kernel
-		tar -cvzf $KERNEL_VERSION-rancheros-v8.tar.gz -C $INSTALL_DIR .
-		sha256sum $KERNEL_VERSION-rancheros-v8.tar.gz > $KERNEL_VERSION-rancheros-v8.tar.gz.sha256
+		echo tar -cvzf $KERNEL_VERSION.tar.gz -C $INSTALL_DIR .
+		tar -cvzf $KERNEL_VERSION.tar.gz -C $INSTALL_DIR .
+		sha256sum $KERNEL_VERSION.tar.gz > $KERNEL_VERSION.tar.gz.sha256
 	popd
 echo "`green [FINISHED]` package kernel files..."
 
@@ -45,13 +49,12 @@ echo "`green [FINISHED]` build firmware files..."
 
 echo "`yellow [STARTING]` copy necessary files to the dest..."
 	pushd ${DOWNLOADS}/kernel
-		cp $KERNEL_VERSION-rancheros-v8.tar.gz* $PACKAGE_KERNEL_DIR
+		cp $KERNEL_VERSION.tar.gz* $PACKAGE_KERNEL_DIR
 		cp bootfiles.tar.gz* $PACKAGE_KERNEL_DIR
 		cp /source/build/kernel/$KERNEL_CONFIG $PACKAGE_KERNEL_DIR
 	popd
 	pushd ${DOWNLOADS}/firmware
 		cp rpi-bootloader.tar.gz* $PACKAGE_FIRMWARE_DIR
 	popd
-	echo "v$KERNEL_VERSION-rancher" > /source/dist/version
 echo "`green [FINISHED]` copy necessary files to the dest..."
 


### PR DESCRIPTION
Adds cross compilation toolchain to dapper process when not on arm64 (currently packages are available on amd64, i386, and ppc64el from debian).

Also bumps version to 4.19 to match current branch of Raspbian.

Kernel built on amd64 tested and boots from branches 4.14.y, 4.19.y, and 5.2.y

With modifications to defconfig, dtb, firmware, and config.txt, a pi4 system can be produced on 4.19.y branch (5.2.y untested).